### PR TITLE
feat: added termux support

### DIFF
--- a/install-nerd-fonts.sh
+++ b/install-nerd-fonts.sh
@@ -115,7 +115,7 @@ set_platform_config() {
             REFRESH_COMMAND="fc-cache -fv"
             PREVIEW_COMMAND="convert -size 600x400 -background white -fill black -font"
             ;;
-	termux)
+        termux)
             FONTS_DIR="${HOME}/.termux/fonts"
             BACKUP_DIR="${HOME}/.termux/fonts.backup"
             REFRESH_COMMAND="termux-reload-settings"

--- a/install-nerd-fonts.sh
+++ b/install-nerd-fonts.sh
@@ -594,7 +594,7 @@ install_font() {
             # For Windows, extract only .ttf and .otf files
             unzip -j "$zip_file" "*.ttf" "*.otf" -d "$font_dir" > /dev/null
             ;;
-	termux)
+    termux)
             # Termux only supports one active font at a time
             unzip -j "$zip_file" "*.ttf" -d "$font_dir" > /dev/null
 


### PR DESCRIPTION
### ✨ Add Termux Support

#### Summary

This PR adds **native Termux support** to the `install-nerd-fonts.sh` script, allowing users on Android devices (via Termux) to install and manage Nerd Fonts seamlessly.

#### Changes

* Added `termux` detection in `detect_os()` by checking:

  * `$TERMUX_VERSION`
  * `$HOME/.termux` directory
* Implemented a **Termux-specific config** in `set_platform_config()`:

  * Fonts directory: `~/.termux/fonts`
  * Backup directory: `~/.termux/fonts.backup`
  * Refresh command: `termux-reload-settings`
* Adjusted `install_font()` logic for Termux:

  * Extracts `.ttf` files only.
  * Copies the first available font to `~/.termux/font.ttf` (since Termux supports a single active font).